### PR TITLE
Feature to fetch resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/
+.git/
+*.py[co]
+*_env/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Also shows how the usage of a authentication header using Concourse variables.
 resources:
     - name: hipchat
       type: http-api
+      check_every: 1h
       source:
           uri: https://www.hipchat.com/v2/room/team_room/notification
           method: POST
@@ -96,6 +97,7 @@ More info: https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API#Remotea
 resources:
     - name: jenkins-trigger-job
       type: http-api
+      check_every: 1h
       source:
           uri: http://user:token@jenkins.example.com/job/job_name/build
           method: POST

--- a/assets/check
+++ b/assets/check
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import json
+import tempfile
+import time
+import sys
+import hashlib
+
+
+def main():
+    data = _get_data()
+    versions = [{'ref': _generate_version_hash()}]
+
+    if data['version']:
+        versions.append(data['version'])
+
+    print(json.dumps(versions))
+
+
+def _get_data():
+    json_data = sys.stdin.read()
+
+    with tempfile.NamedTemporaryFile(delete=False, prefix='check-') as f:
+        f.write(bytes(json_data, 'utf-8'))
+
+    data = json.loads(json_data)
+    return data
+
+
+def _generate_version_hash():
+    time_str = '%s' % time.time()
+    hash_object = hashlib.md5(time_str.encode())
+    hash_str = hash_object.hexdigest()
+
+    return hash_str[:6]
+
+if __name__ == '__main__':
+    main()

--- a/assets/check
+++ b/assets/check
@@ -2,17 +2,19 @@
 
 import json
 import tempfile
-import time
 import sys
-import hashlib
+
+from resource import generate_version_hash
 
 
 def main():
     data = _get_data()
-    versions = [{'ref': _generate_version_hash()}]
+    versions = []
 
     if data['version']:
         versions.append(data['version'])
+
+    versions.append({'ref': generate_version_hash()})
 
     print(json.dumps(versions))
 
@@ -26,13 +28,6 @@ def _get_data():
     data = json.loads(json_data)
     return data
 
-
-def _generate_version_hash():
-    time_str = '%s' % time.time()
-    hash_object = hashlib.md5(time_str.encode())
-    hash_str = hash_object.hexdigest()
-
-    return hash_str[:6]
 
 if __name__ == '__main__':
     main()

--- a/assets/in
+++ b/assets/in
@@ -1,4 +1,44 @@
-#!/bin/sh
+#!/usr/bin/env python3
 
-# empty response to have non-failing implicit get after put
-echo "{}"
+import hashlib
+import json
+import os
+import sys
+import time
+
+from resource import HTTPResource
+
+
+def main():
+    """main function for `in` command """
+    response = HTTPResource().run(os.path.basename(__file__), sys.stdin.read(), sys.argv[1:])
+    _save_response(response, sys.argv[1])
+
+    response_dict = {
+      "version": {"ref": _generate_version_hash()},
+      "metadata": [
+        { "name": "payload", "value": response[:100] },
+      ]
+    }
+
+    print (json.dumps(response_dict))
+
+
+def _save_response(json_data, file_path):
+    """save json content as file """
+    file_name = '%s/response.json' % os.path.abspath(file_path)
+
+    fo = open(file_name, "wb")
+    fo.write(bytes(json_data, 'utf-8'))
+    fo.close()
+
+
+def _generate_version_hash():
+    time_str = '%s' % time.time()
+    hash_object = hashlib.md5(time_str.encode())
+    hash_str = hash_object.hexdigest()
+
+    return hash_str[:6]
+
+if __name__ == '__main__':
+    main()

--- a/assets/in
+++ b/assets/in
@@ -1,44 +1,43 @@
 #!/usr/bin/env python3
 
-import hashlib
 import json
 import os
 import sys
 import time
 
-from resource import HTTPResource
+from resource import HTTPResource, generate_version_hash
 
 
 def main():
     """main function for `in` command """
-    response = HTTPResource().run(os.path.basename(__file__), sys.stdin.read(), sys.argv[1:])
-    _save_response(response, sys.argv[1])
+    http_resource = HTTPResource(os.path.basename(__file__), sys.stdin.read())
+
+    response = http_resource.run(sys.argv[1:])
+    _save_response(http_resource.http_response_payload, sys.argv[1])
+
+    version = http_resource.input_data.get('version')
+    if not version.get('ref') or version.get('ref') == '':
+        version = {"ref": generate_version_hash()}
 
     response_dict = {
-      "version": {"ref": _generate_version_hash()},
+      "version": version,
       "metadata": [
-        { "name": "payload", "value": response[:100] },
+        {"name": "time", "value": str(time.time())},
+        {"name": "http_response_code", "value": str(http_resource.http_response_code)},
+        {"name": "http_response_payload", "value": '%s [...]' % http_resource.http_response_payload[:100]},
       ]
     }
 
     print (json.dumps(response_dict))
 
 
-def _save_response(json_data, file_path):
+def _save_response(response_data, file_path):
     """save json content as file """
     file_name = '%s/response.json' % os.path.abspath(file_path)
 
     fo = open(file_name, "wb")
-    fo.write(bytes(json_data, 'utf-8'))
+    fo.write(bytes(response_data, 'utf-8'))
     fo.close()
-
-
-def _generate_version_hash():
-    time_str = '%s' % time.time()
-    hash_object = hashlib.md5(time_str.encode())
-    hash_str = hash_object.hexdigest()
-
-    return hash_str[:6]
 
 if __name__ == '__main__':
     main()

--- a/assets/resource.py
+++ b/assets/resource.py
@@ -9,7 +9,7 @@ import tempfile
 import requests
 
 
-class HTTPResource:
+class HTTPResource(object):
     """HTTP resource implementation."""
 
     def cmd(self, arg, data):
@@ -87,7 +87,11 @@ class HTTPResource:
         if os.environ.get('TEST', False):
             response.update(json.loads(text))
 
-        return json.dumps(response)
+
+        payload = json.dumps(response)
+        log.debug('payload: %s', payload)
+
+        return payload
 
     def _interpolate(self, data, values):
         """Recursively apply values using format on all string key and values in data."""
@@ -105,4 +109,6 @@ class HTTPResource:
 
         return rendered
 
-print(HTTPResource().run(os.path.basename(__file__), sys.stdin.read(), sys.argv[1:]))
+
+if __name__ == '__main__':
+    print(HTTPResource().run(os.path.basename(__file__), sys.stdin.read(), sys.argv[1:]))

--- a/assets/resource.py
+++ b/assets/resource.py
@@ -5,12 +5,22 @@ import logging as log
 import os
 import sys
 import tempfile
+import time
 
 import requests
 
 
 class HTTPResource(object):
     """HTTP resource implementation."""
+
+    def __init__(self, command_name: str, json_data: str):
+        """Init method for HTTPResource."""
+        self.command_name = command_name
+        self.input_data = self._get_input_data(json_data)
+
+        self.http_response_code = 0
+        self.http_response_payload = ''
+
 
     def cmd(self, arg, data):
         """Make the requests."""
@@ -35,24 +45,19 @@ class HTTPResource(object):
         response = requests.request(method, uri, json=json_data,
             data=request_data, headers=headers, verify=verify)
 
-        log.info('http response code: %s', response.status_code)
-        log.info('http response text: %s', response.text)
+        self.http_response_code = response.status_code
+        self.http_response_payload = response.text
 
         if response.status_code not in ok_responses:
             raise Exception('Unexpected response {}'.format(response.status_code))
 
         return (response.status_code, response.text)
 
-    def run(self, command_name: str, json_data: str, command_argument: str):
+    def run(self, command_argument: str):
         """Parse input/arguments, perform requested command return output."""
 
-        with tempfile.NamedTemporaryFile(delete=False, prefix=command_name + '-') as f:
-            f.write(bytes(json_data, 'utf-8'))
-
-        data = json.loads(json_data)
-
         # allow debug logging to console for tests
-        if os.environ.get('RESOURCE_DEBUG', False) or data.get('source', {}).get('debug', False):
+        if os.environ.get('RESOURCE_DEBUG', False) or self.input_data.get('source', {}).get('debug', False):
             log.basicConfig(level=log.DEBUG)
         else:
             logfile = tempfile.NamedTemporaryFile(delete=False, prefix='log')
@@ -61,8 +66,8 @@ class HTTPResource(object):
             stderr.setLevel(log.INFO)
             log.getLogger().addHandler(stderr)
 
-        log.debug('command: %s', command_name)
-        log.debug('input: %s', data)
+        log.debug('command: %s', self.command_name)
+        log.debug('input: %s', self.input_data)
         log.debug('args: %s', command_argument)
         log.debug('environment: %s', os.environ)
 
@@ -70,8 +75,8 @@ class HTTPResource(object):
         values = {k: v for k, v in os.environ.items() if k.startswith('BUILD_') or k == 'ATC_EXTERNAL_URL'}
 
         # combine source and params
-        params = data.get('source', {})
-        params.update(data.get('params', {}))
+        params = self.input_data.get('source', {})
+        params.update(self.input_data.get('params', {}))
 
         # allow also to interpolate params
         values.update(params)
@@ -79,19 +84,36 @@ class HTTPResource(object):
         # apply templating of environment variables onto parameters
         rendered_params = self._interpolate(params, values)
 
-        status_code, text = self.cmd(command_argument, rendered_params)
+        http_status_code, http_payload = self.cmd(command_argument, rendered_params)
+
+        log.debug('http response code: %s', http_status_code)
+        log.debug('http response payload: %s', http_payload)
 
         # return empty version object
-        response = {"version": {}}
+        response = {
+            "version": {},
+            "metadata": [
+                {"name": "time", "value": str(time.time())},
+                {"name": "http_response_code", "value": str(http_status_code)},
+                {"name": "http_response_payload", "value": '%s [...]' % http_payload[:100]}
+            ]
+        }
 
         if os.environ.get('TEST', False):
-            response.update(json.loads(text))
-
+            response.update(json.loads(http_payload))
 
         payload = json.dumps(response)
         log.debug('payload: %s', payload)
 
         return payload
+
+
+    def _get_input_data(self, json_data: str):
+        with tempfile.NamedTemporaryFile(delete=False, prefix=self.command_name + '-') as f:
+            f.write(bytes(json_data, 'utf-8'))
+
+        return json.loads(json_data)
+
 
     def _interpolate(self, data, values):
         """Recursively apply values using format on all string key and values in data."""
@@ -110,5 +132,11 @@ class HTTPResource(object):
         return rendered
 
 
+def generate_version_hash():
+    """Generate a version string."""
+    time_str = time.strftime("%Y%m%d.%H%M%S")
+    return str(time_str)
+
+
 if __name__ == '__main__':
-    print(HTTPResource().run(os.path.basename(__file__), sys.stdin.read(), sys.argv[1:]))
+    print(HTTPResource(os.path.basename(__file__), sys.stdin.read()).run(sys.argv[1:]))

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -7,6 +7,7 @@ ENVIRONMENT = {
     'BUILD_NAME': '1',
     'BUILD_JOB_NAME': 'test-job',
     'BUILD_PIPELINE_NAME': 'test-pipeline',
+    'BUILD_TEAM_NAME': 'test-team',
     'BUILD_ID': '123',
     'TEST': 'true',
 }
@@ -21,7 +22,15 @@ def cmd(cmd_name, source, args: list = [], version={}, params={}):
     })
     command = ['/opt/resource/' + cmd_name] + args
     environment = dict(os.environ, **ENVIRONMENT)
+
     output = subprocess.check_output(command, env=environment,
         stderr=sys.stderr, input=bytes(in_json, 'utf-8'))
 
-    return json.loads(output.decode())
+    if cmd_name == 'in':
+        file_name = '%s/response.json' % args[0]
+        with open(file_name) as data_file:
+            json_data = json.load(data_file)
+    else:
+        json_data = json.loads(output.decode())
+
+    return json_data

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -26,11 +26,4 @@ def cmd(cmd_name, source, args: list = [], version={}, params={}):
     output = subprocess.check_output(command, env=environment,
         stderr=sys.stderr, input=bytes(in_json, 'utf-8'))
 
-    if cmd_name == 'in':
-        file_name = '%s/response.json' % args[0]
-        with open(file_name) as data_file:
-            json_data = json.load(data_file)
-    else:
-        json_data = json.loads(output.decode())
-
-    return json_data
+    return json.loads(output.decode())

--- a/test/test_invocation.py
+++ b/test/test_invocation.py
@@ -68,3 +68,39 @@ def test_data_urlencode(httpbin):
     output = cmd('out', source)
 
     assert output['form'] == {'field': '{"test": 123}'}
+
+def test_check(httpbin):
+    """Json should be passed as JSON content."""
+
+    source = {
+        'uri': httpbin + '/post',
+        'method': 'POST',
+        'json': {
+            'test': 123,
+        },
+    }
+
+    output = cmd('check', source, version={'ref': '123'})
+
+    ref_0 = output[0]
+    ref_1 = output[1]
+
+    print(output)
+
+    assert ref_0.get('ref') != '123'
+    assert ref_1.get('ref') == '123'
+
+def test_json_in(httpbin):
+    """Json should be passed as JSON content."""
+
+    source = {
+        'uri': httpbin + '/post',
+        'method': 'POST',
+        'json': {
+            'test': 987,
+        },
+    }
+
+    output = cmd('in', source, args=['/tmp'])
+
+    assert output['json']['test'] == 987

--- a/test/test_invocation.py
+++ b/test/test_invocation.py
@@ -85,10 +85,10 @@ def test_check(httpbin):
     ref_0 = output[0]
     ref_1 = output[1]
 
-    print(output)
+    assert ref_0.get('ref') == '123'
 
-    assert ref_0.get('ref') != '123'
-    assert ref_1.get('ref') == '123'
+    assert ref_1.get('ref') != ''
+    assert ref_1.get('ref') != '123'
 
 def test_json_in(httpbin):
     """Json should be passed as JSON content."""
@@ -101,6 +101,13 @@ def test_json_in(httpbin):
         },
     }
 
-    output = cmd('in', source, args=['/tmp'])
+    output = cmd('in', source, args=['/tmp'], version={'ref': '123'})
 
-    assert output['json']['test'] == 987
+    assert output['version']['ref'] == '123'
+    for meta_object in output['metadata']:
+        if meta_object.get('name') == 'http_response_code':
+            assert meta_object.get('value') == '200'
+
+    with open('/tmp/response.json') as data_file:
+        json_data = json.load(data_file)
+        assert json_data['json']['test'] == 987


### PR DESCRIPTION
This PR will add the possibility to use the http-api resource also as "get" resource for tasks.
The api response can be found under "<destination_directory>/response.json" in the task container.

In my use case the updated version works as expected. If you want to test the implementation you can reuse my docker image if you want:

```sh
docker push msiebeneicher/concourse-resources:http-api-resource-dev
```