### PR TITLE
Fix compatibility with Concourse 3.1.1

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# empty response to keep Concourse happy
+echo "[]"


### PR DESCRIPTION
By implementing all three parts of the Resource interface.

Concourse 3.1.1's web view [will break without this](https://github.com/concourse/concourse/issues/1265), and as a bonus this
should get rid of scary logs like

```
{"error":"hijack: Backend error: Exit status: 500, message:
{\"Type\":\"\",\"Message\":\"runc exec: exit status 1: exec failed:
container_linux.go:264: starting container process caused \\\"exec:
\\\\\\\"/opt/resource/check\\\\\\\": stat /opt/resource/check: no such
file or directory\\\"\\n\",\"Handle\":\"\"}\n"
```