### PR TITLE
issue #9

### DIFF
--- a/assets/resource.py
+++ b/assets/resource.py
@@ -30,7 +30,7 @@ class HTTPResource:
 
         request_data = None
         if form_data:
-            request_data = {k: json.dumps(v) for k, v in form_data.items()}
+            request_data = {k: json.dumps(v, ensure_ascii=False) for k, v in form_data.items()}
 
         response = requests.request(method, uri, json=json_data,
                                     data=request_data, headers=headers, verify=verify)

--- a/test/test_invocation.py
+++ b/test/test_invocation.py
@@ -107,3 +107,21 @@ def test_data_urlencode(httpbin):
     output = cmd('out', source)
 
     assert output['form'] == {'field': '{"test": 123}'}
+
+
+def test_data_ensure_ascii(httpbin):
+    """Test form_data json ensure_ascii."""
+
+    source = {
+        'uri': httpbin + '/post',
+        'method': 'POST',
+        'form_data': {
+            'field': {
+                'test': '日本語',
+            },
+        },
+    }
+
+    output = cmd('out', source)
+
+    assert output['form'] == {'field': '{"test": "日本語"}'}


### PR DESCRIPTION
use `json.dumps(v, ensure_ascii=False)`

Sample:
```
      form_data:
        body: "Hello! Build {BUILD_PIPELINE_NAME} {BUILD_JOB_NAME}, nr: {BUILD_NAME} 日本語？ {message}!"
```

Before result:
```
"Hello! Build my-template hello, nr: 4 \u65e5\u672c\u8a9e\uff1f \u3067\u304d\u308b\u304b\u306a\uff1f!"
```

After result:
```
"Hello! Build my-template hello, nr: 8 日本語？ できるかな？!"
```
