### PR TITLE
Add parameter to pass data encoded as a form

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Options set in `params` take precedence over options in `source`.
 
 * `form_data`: *Optional* Dictionary with form field/value pairs to send as data. Values are converted to JSON and URL-encoded.
 
+* `parse_form_data`: *Optional* Boolean to specify if form_data should be converted to JSON or not (default `true`). If false, set `"Content-Type":"application/x-www-form-urlencoded"` header.
+
 ## Behavior
 
 Currently the only useful action the resource supports is `out`. The actions `in` and `check` will be added later.
@@ -129,4 +131,32 @@ jobs:
 
           - put: jenkins-trigger-job
 
+```
+
+
+### Call a Rest API with data formated in a standard form
+
+Register apps on a Spring Cloud Data Flow instance via a `POST` formated with `application/x-www-form-urlencoded` encoding type.
+
+More info: https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#resources-app-registry-bulk
+
+```yaml
+resources:
+- name: dataflow-rest-api
+  type: http-api
+  source:
+    uri: http://my-dataflow-platform.org
+
+jobs:
+- name: load-apps
+  public: true
+  plan:
+  - put: dataflow-rest-api
+    params:
+      uri: http://my-dataflow-platform.org/apps
+      method: POST
+      debug: true
+      parse_form_data: false
+      form_data:
+        uri: http://artefact.my-repo.com/artifactory/Maven/appsList/0.0.1/appsList-0.0.1.properties
 ```

--- a/assets/resource.py
+++ b/assets/resource.py
@@ -22,6 +22,7 @@ class HTTPResource:
         ssl_verify = data.get('ssl_verify', True)
         ok_responses = data.get('ok_responses', [200, 201, 202, 204])
         form_data = data.get('form_data')
+        parse_form_data = data.get('parse_form_data', True)
 
         if isinstance(ssl_verify, bool):
             verify = ssl_verify
@@ -29,8 +30,10 @@ class HTTPResource:
             verify = str(tempfile.NamedTemporaryFile(delete=False, prefix='ssl-').write(verify))
 
         request_data = None
-        if form_data:
+        if form_data and parse_form_data:
             request_data = {k: json.dumps(v, ensure_ascii=False) for k, v in form_data.items()}
+        elif form_data and not parse_form_data:
+            request_data = form_data
 
         response = requests.request(method, uri, json=json_data,
                                     data=request_data, headers=headers, verify=verify)

--- a/test/test_invocation.py
+++ b/test/test_invocation.py
@@ -131,3 +131,22 @@ def test_data_ensure_ascii(httpbin):
     output = cmd('out', source)
 
     assert output['form'] == {'field': '{"test": "日本語"}'}
+
+
+def test_not_parsed_data(httpbin):
+    """Test form_data in a standard format."""
+
+    source = {
+        'uri': httpbin + '/post',
+        'method': 'POST',
+        'parse_form_data': False,
+        'form_data': {
+            'firstname': 'John',
+            'lastname': 'Doe'
+        }
+    }
+
+    output = cmd('out', source)
+
+    assert output['form'] == {"firstname":"John","lastname":"Doe"}
+    assert output['version'] == {}


### PR DESCRIPTION
... and place "Content-Type":"application/x-www-form-urlencoded" header.

The new parameter is `parse_form_data`. It's an optional boolean to specify if form_data should be converted to JSON or not (set to `true` by default to ensure backward compatibility).

fix #17 